### PR TITLE
Apple keys getting issue for production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in apple_sign_in.gemspec
 gemspec
+
+gem "faraday", "~> 2.7"

--- a/lib/apple_auth/helpers/jwt_decoder.rb
+++ b/lib/apple_auth/helpers/jwt_decoder.rb
@@ -23,7 +23,7 @@ module AppleAuth
     end
 
     def apple_key_hash(jwt)
-      response = Net::HTTP.get(URI.parse(APPLE_KEY_URL))
+      response = Faraday.get(AppleAuth::UserIdentity::APPLE_KEY_URL).body
       certificate = JSON.parse(response)
       matching_key = certificate['keys'].select { |key| key['kid'] == jwt_kid(jwt) }
       ActiveSupport::HashWithIndifferentAccess.new(matching_key.first)


### PR DESCRIPTION
### Summary
- On Production,  it gives the error on Net::HTTP is returning 403 Forbidden on getting Apple Auth Keys
### FIx
- get the apple key with the faraday gem. 